### PR TITLE
Added Particle Auto Complete

### DIFF
--- a/common/src/main/java/com/mt1006/nbt_ac/autocomplete/ParticleSuggestionManager.java
+++ b/common/src/main/java/com/mt1006/nbt_ac/autocomplete/ParticleSuggestionManager.java
@@ -1,0 +1,43 @@
+package com.mt1006.nbt_ac.autocomplete;
+
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import com.mt1006.nbt_ac.autocomplete.suggestions.RawSuggestion;
+import com.mt1006.nbt_ac.utils.RegistryUtils;
+import net.minecraft.resources.Identifier;
+
+import java.util.concurrent.CompletableFuture;
+
+public class ParticleSuggestionManager
+{
+	private static final String PARTICLE_ROOT = "particle/";
+
+	public static CompletableFuture<Suggestions> load(SuggestionsBuilder suggestionsBuilder)
+	{
+		String remaining = suggestionsBuilder.getRemaining();
+		int optionsStart = remaining.indexOf('{');
+
+		if (optionsStart == -1)
+		{
+			return suggestParticleIds(suggestionsBuilder);
+		}
+
+		Identifier particleId = Identifier.tryParse(remaining.substring(0, optionsStart));
+		if (particleId == null)
+		{
+			return suggestParticleIds(suggestionsBuilder);
+		}
+
+		SuggestionsBuilder optionBuilder = suggestionsBuilder.createOffset(suggestionsBuilder.getStart() + optionsStart);
+		return NbtSuggestionManager.loadFromName(PARTICLE_ROOT + particleId, optionBuilder.getRemaining(), optionBuilder, false);
+	}
+
+	private static CompletableFuture<Suggestions> suggestParticleIds(SuggestionsBuilder suggestionsBuilder)
+	{
+		SuggestionList suggestionList = new SuggestionList();
+		RegistryUtils.PARTICLE_TYPE.keySet().forEach((id) ->
+				suggestionList.add(new RawSuggestion(id.toString(), "[#particle]")));
+		suggestionList.forEach((suggestion) -> suggestion.suggest(suggestionsBuilder));
+		return suggestionsBuilder.buildFuture();
+	}
+}

--- a/common/src/main/java/com/mt1006/nbt_ac/mixin/suggestions/arguments/ParticleArgumentMixin.java
+++ b/common/src/main/java/com/mt1006/nbt_ac/mixin/suggestions/arguments/ParticleArgumentMixin.java
@@ -1,0 +1,28 @@
+package com.mt1006.nbt_ac.mixin.suggestions.arguments;
+
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import com.mt1006.nbt_ac.autocomplete.ParticleSuggestionManager;
+import net.minecraft.commands.arguments.ParticleArgument;
+import net.minecraft.core.particles.ParticleOptions;
+import org.spongepowered.asm.mixin.Mixin;
+
+import java.util.concurrent.CompletableFuture;
+
+@Mixin(ParticleArgument.class)
+public abstract class ParticleArgumentMixin implements ArgumentType<ParticleOptions>
+{
+	@Override public <S> CompletableFuture<Suggestions> listSuggestions(CommandContext<S> commandContext, SuggestionsBuilder suggestionsBuilder)
+	{
+		try
+		{
+			return ParticleSuggestionManager.load(suggestionsBuilder);
+		}
+		catch (Exception e)
+		{
+			return Suggestions.empty();
+		}
+	}
+}

--- a/common/src/main/java/com/mt1006/nbt_ac/utils/RegistryUtils.java
+++ b/common/src/main/java/com/mt1006/nbt_ac/utils/RegistryUtils.java
@@ -3,6 +3,7 @@ package com.mt1006.nbt_ac.utils;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.particles.ParticleType;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
@@ -25,6 +26,7 @@ public class RegistryUtils
 	public static final LocalRegistry<EntityType<?>> ENTITY_TYPE = new LocalRegistry<>(BuiltInRegistries.ENTITY_TYPE);
 	public static final LocalRegistry<BlockEntityType<?>> BLOCK_ENTITY_TYPE = new LocalRegistry<>(BuiltInRegistries.BLOCK_ENTITY_TYPE);
 	public static final LocalRegistry<DataComponentType<?>> DATA_COMPONENT_TYPE = new LocalRegistry<>(BuiltInRegistries.DATA_COMPONENT_TYPE);
+	public static final LocalRegistry<ParticleType<?>> PARTICLE_TYPE = new LocalRegistry<>(BuiltInRegistries.PARTICLE_TYPE);
 
 	public static class LocalRegistry<T> implements Iterable<T>
 	{

--- a/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/compound/particle_block_state.json
+++ b/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/compound/particle_block_state.json
@@ -1,0 +1,20 @@
+{
+	"id": "compound/nbt_ac:particle_block_state",
+
+	"tags":
+	[
+		{
+			"tag": "Name",
+			"type": "string",
+			"subtype": "registry_key/minecraft:block",
+			"recommended": true
+		},
+
+		{
+			"tag": "Properties",
+			"type": "compound",
+			"subtype": "block_state_tag/*",
+			"with": "#parent/Name"
+		}
+	]
+}

--- a/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/compound/particle_position_source.json
+++ b/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/compound/particle_position_source.json
@@ -1,0 +1,19 @@
+{
+	"id": "compound/nbt_ac:particle_position_source",
+
+	"tags":
+	[
+		{
+			"tag": "type",
+			"type": "string",
+			"subtype": "enum/block",
+			"recommended": true
+		},
+
+		{
+			"tag": "pos",
+			"type": "list/int",
+			"recommended": true
+		}
+	]
+}

--- a/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/block_particle_options.json
+++ b/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/block_particle_options.json
@@ -1,0 +1,19 @@
+{
+	"apply_to":
+	[
+		"particle/minecraft:block",
+		"particle/minecraft:block_marker",
+		"particle/minecraft:falling_dust",
+		"particle/minecraft:dust_pillar",
+		"particle/minecraft:block_crumble"
+	],
+	"tags":
+	[
+		{
+			"tag": "block_state",
+			"type": "compound",
+			"subtype": "tag/compound/nbt_ac:particle_block_state",
+			"recommended": true
+		}
+	]
+}

--- a/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/color_particle_options.json
+++ b/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/color_particle_options.json
@@ -1,0 +1,16 @@
+{
+	"apply_to":
+	[
+		"particle/minecraft:entity_effect",
+		"particle/minecraft:flash",
+		"particle/minecraft:tinted_leaves"
+	],
+	"tags":
+	[
+		{
+			"tag": "color",
+			"type": "int",
+			"recommended": true
+		}
+	]
+}

--- a/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/dust.json
+++ b/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/dust.json
@@ -1,0 +1,17 @@
+{
+	"id": "particle/minecraft:dust",
+	"tags":
+	[
+		{
+			"tag": "color",
+			"type": "int",
+			"recommended": true
+		},
+
+		{
+			"tag": "scale",
+			"type": "float",
+			"recommended": true
+		}
+	]
+}

--- a/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/dust_color_transition.json
+++ b/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/dust_color_transition.json
@@ -1,0 +1,23 @@
+{
+	"id": "particle/minecraft:dust_color_transition",
+	"tags":
+	[
+		{
+			"tag": "from_color",
+			"type": "int",
+			"recommended": true
+		},
+
+		{
+			"tag": "to_color",
+			"type": "int",
+			"recommended": true
+		},
+
+		{
+			"tag": "scale",
+			"type": "float",
+			"recommended": true
+		}
+	]
+}

--- a/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/item.json
+++ b/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/item.json
@@ -1,0 +1,12 @@
+{
+	"id": "particle/minecraft:item",
+	"tags":
+	[
+		{
+			"tag": "item",
+			"type": "compound",
+			"subtype": "tag/compound/nbt_ac:item",
+			"recommended": true
+		}
+	]
+}

--- a/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/power_particle_options.json
+++ b/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/power_particle_options.json
@@ -1,0 +1,14 @@
+{
+	"apply_to":
+	[
+		"particle/minecraft:dragon_breath"
+	],
+	"tags":
+	[
+		{
+			"tag": "power",
+			"type": "float",
+			"recommended": true
+		}
+	]
+}

--- a/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/sculk_charge.json
+++ b/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/sculk_charge.json
@@ -1,0 +1,11 @@
+{
+	"id": "particle/minecraft:sculk_charge",
+	"tags":
+	[
+		{
+			"tag": "roll",
+			"type": "float",
+			"recommended": true
+		}
+	]
+}

--- a/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/shriek.json
+++ b/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/shriek.json
@@ -1,0 +1,11 @@
+{
+	"id": "particle/minecraft:shriek",
+	"tags":
+	[
+		{
+			"tag": "delay",
+			"type": "int",
+			"recommended": true
+		}
+	]
+}

--- a/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/spell_particle_options.json
+++ b/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/spell_particle_options.json
@@ -1,0 +1,20 @@
+{
+	"apply_to":
+	[
+		"particle/minecraft:effect",
+		"particle/minecraft:instant_effect"
+	],
+	"tags":
+	[
+		{
+			"tag": "color",
+			"type": "int"
+		},
+
+		{
+			"tag": "power",
+			"type": "float",
+			"recommended": true
+		}
+	]
+}

--- a/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/trail.json
+++ b/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/trail.json
@@ -1,0 +1,23 @@
+{
+	"id": "particle/minecraft:trail",
+	"tags":
+	[
+		{
+			"tag": "target",
+			"type": "list/double",
+			"recommended": true
+		},
+
+		{
+			"tag": "color",
+			"type": "int",
+			"recommended": true
+		},
+
+		{
+			"tag": "duration",
+			"type": "int",
+			"recommended": true
+		}
+	]
+}

--- a/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/vibration.json
+++ b/common/src/main/resources/assets/nbt_ac/nbt_ac_suggestions_v2/tags/particle/vibration.json
@@ -1,0 +1,18 @@
+{
+	"id": "particle/minecraft:vibration",
+	"tags":
+	[
+		{
+			"tag": "destination",
+			"type": "compound",
+			"subtype": "tag/compound/nbt_ac:particle_position_source",
+			"recommended": true
+		},
+
+		{
+			"tag": "arrival_in_ticks",
+			"type": "int",
+			"recommended": true
+		}
+	]
+}

--- a/common/src/main/resources/nbt_ac.mixins.json
+++ b/common/src/main/resources/nbt_ac.mixins.json
@@ -23,6 +23,7 @@
     "misc.ArgumentCommandNodeMixin",
     "suggestions.SuggestionsListMixin",
     "suggestions.arguments.ComponentArgumentMixin",
+    "suggestions.arguments.ParticleArgumentMixin",
     "suggestions.arguments.CompoundTagArgumentMixin",
     "suggestions.arguments.NbtPathArgumentMixin",
     "suggestions.arguments.NbtTagArgumentMixin",


### PR DESCRIPTION
## Changes

The `/particle` command now supports autocompletion for the following particle types:

- `particle_block_state`
- `particle_position_source`
- `block_particle_options`
- `color_particle_options`
- `dust`
- `dust_color_transition`
- `item`
- `power_particle_options`
- `sculk_charge`
- `shriek`
- `spell_particle_options`
- `trail`
- `vibration`